### PR TITLE
Display more than the first 5 rows of signatures, references and files

### DIFF
--- a/spec/spec/serializers/docTypeSerializers.py
+++ b/spec/spec/serializers/docTypeSerializers.py
@@ -22,3 +22,10 @@ class DocTypePutSerializer(serializers.ModelSerializer):
         model = DocType
         fields = ('descr', 'confidential', 'jira_temp', 'sunset_interval', 'sunset_warn',  )
 
+    def update(self, doctype, validated_data):
+        if not validated_data['sunset_interval']:
+            validated_data['sunset_interval'] = None
+        if not validated_data['sunset_warn']:
+            validated_data['sunset_warn'] = None
+            
+        return super(DocTypePutSerializer, self).update(doctype, validated_data)

--- a/spec/spec/views/docTypeViews.py
+++ b/spec/spec/views/docTypeViews.py
@@ -72,7 +72,9 @@ class DocTypeDetail(APIView):
         "name": "WI",
         "descr": "Work Instruction",
         "confidential": false,
-        "jira_temp": ""
+        "jira_temp": "",
+        "sunset_interval": "1096 00:00:00",
+        "sunset_warn": "90 00:00:00",
     }
 
     delete:

--- a/spec/ui/src/views/spec/SpecDetail.vue
+++ b/spec/ui/src/views/spec/SpecDetail.vue
@@ -150,6 +150,7 @@
         <q-card-section class="q-pt-none row">
             <q-table
                 :rows="sigRows"
+                :rows-per-page-options="[0]"
                 hide-bottom
                 data-cy="spec-detail-sigs">
                 <template v-slot:header>
@@ -220,6 +221,7 @@
             <q-space/>
             <q-table
                 :rows="refRows"
+                :rows-per-page-options="[0]"
                 hide-bottom
                 data-cy="spec-detail-refs">
                 <template v-slot:top-left>
@@ -268,6 +270,7 @@
             <q-space/>
             <q-table
                 :rows="fileRows"
+                :rows-per-page-options="[0]"
                 hide-bottom
                 data-cy="spec-detail-files">
                 <template v-slot:top-left>
@@ -337,6 +340,7 @@
             <span class="row">
                 <q-table
                     :rows="histRows"
+                    :rows-per-page-options="[0]"
                     hide-bottom
                     data-cy="spec-detail-files">
                     <template v-slot:header>


### PR DESCRIPTION
Allow clearing the sunset fields on the doc type from the UI.